### PR TITLE
Remove microsemi-aacraid dependency

### DIFF
--- a/SPECS/vendor-drivers.spec
+++ b/SPECS/vendor-drivers.spec
@@ -5,7 +5,7 @@
 Summary: Vendor drivers
 Name: vendor-drivers
 Version: 2.0.3
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: Public Domain
 
 # This package has no source, no thing to prep, build or install, and no files.
@@ -28,7 +28,6 @@ Requires: intel-igb
 Requires: intel-igc
 Requires: intel-ixgbe
 Requires: mellanox-mlnxen
-Requires: microsemi-aacraid
 Requires: microsemi-smartpqi
 Requires: qlogic-fastlinq
 Requires: qlogic-netxtreme2
@@ -45,6 +44,9 @@ Virtual package with dependencies on all vendor-provided kernel device drivers.
 %files
 
 %changelog
+* Wed Jun 04 2026 Julian Vetter <julian.vetter@vates.tech> - 2.0.3-1.2
+- Remove microsemi-aacraid dependency; fall back to in-kernel aacraid driver
+
 * Thu Jun 20 2024 Samuel Verschelde <stormi-xcp@ylix.fr> - 2.0.3-1.1
 - Rebase on 2.0.3-1
 - Switch dependency from our igc-module to the new intel-igc


### PR DESCRIPTION
The microsemi-aacraid driver from this RPM has proven to be unreliable. It has several issues and hasn't been updated for a while. So, drop the dependency here. In will then fall back to in-kernel aacraid driver which is better maintained and worked in XCP-ng 8.2.

### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-2851

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

As described above the oot microsemi-aacraid driver from the RPM has proven to be unreliable. It has several issues and hasn't been updated for a while. It requires several upstream patches to be en-par with the in-kernel driver. So, why not directly use the in-tree driver? So, in a first step we drop the dependency here. In will then fall back to in-kernel aacraid driver which is better maintained and worked in XCP-ng 8.2 (for certain cards we might need the driver argument `aacraid.numacb=1000`). 


#### Release Target

- [ ] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [x] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

Samuel: the natural next milestone, without any other visible constraints: 8.3-next :white_check_mark: 

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

The oot microsemi-aacraid driver from the RPM has proven to be unreliable. It has several issues, is missing patches from upstream and hasn't been updated for a while. So, we switch back to the in-tree driver just like XCP-ng 8.2 was doing.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->



#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->



<!-- Add links to the documentation update PRs if/when they are created. -->

N/A

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

None. We don't have this raid card so we can't test it internally. We will need an external person to test it.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

The new ISO installer should be booted on a machine with an aacraid controller to test if it's properly probed.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

n/a

#### What tests have been or will be added to CI for this change? If none, explain why.

We don't have a mircosemi raid card that uses this driver. So, no testing can be performed on our side.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No
- [ ] I don't know

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
